### PR TITLE
Create GitHub Workflow for CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,15 @@
 
 name: Build
 
-on: push
+on:
+  push:
+  # Run this workflow when a release is published using GitHub's web UI.
+  # Pre-releases will also trigger the workflow, but draft releases won't.
+  release:
+    types: [published]
+
+env:
+  PIP_REQUIREMENTS: requirements-dev.txt
 
 jobs:
   test:
@@ -13,9 +21,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
-
-    env:
-      PIP_REQUIREMENTS: requirements-dev.txt
 
     steps:
     - uses: actions/checkout@v2
@@ -51,3 +56,33 @@ jobs:
         pip install -r ${{ env.PIP_REQUIREMENTS }}
     - name: Test with tox
       run: tox -e py
+
+  publish:
+
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    env:
+      python-version: 3.8
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ env.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ env.python-version }}
+    # Manual build step required because tox only builds an sdist and not wheels.
+    - name: Build distributions
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ env.PIP_REQUIREMENTS }}
+        python setup.py sdist bdist_wheel
+    - name: Publish package to TestPyPI
+      # Use SHA-1 hash because this GitHub Action isn't mature yet
+      # TODO: Replace hash with a tag name when this becomes stable
+      uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,47 @@ env:
   PIP_REQUIREMENTS: requirements-dev.txt
 
 jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      python-version: 3.8
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ env.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ env.python-version }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ env.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies (${{ env.PIP_REQUIREMENTS }})
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ env.PIP_REQUIREMENTS }}
+
+    # Manual build step required because tox only builds an sdist and not wheels
+    - name: Build distributions
+      run: python setup.py sdist bdist_wheel
+
+    - name: Upload distributions
+      uses: actions/upload-artifact@v1
+      with:
+        name: distributions
+        path: dist
+
   test:
 
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -54,8 +93,21 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r ${{ env.PIP_REQUIREMENTS }}
-    - name: Test with tox
-      run: tox -e py
+
+    - name: Download distributions
+      uses: actions/download-artifact@v1
+      with:
+        name: distributions
+        path: dist
+
+    # Use wildcard expansion to select a single distribution file to test
+    # (requires bash)
+    - name: Test with tox (sdist)
+      run: tox -e py --installpkg dist/*.tar.gz
+      shell: bash
+    - name: Test with tox (wheel)
+      run: tox -e py --installpkg dist/*-any.whl
+      shell: bash
 
   publish:
 
@@ -63,21 +115,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
 
-    env:
-      python-version: 3.8
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v1
+    - name: Download distributions
+      uses: actions/download-artifact@v1
       with:
-        python-version: ${{ env.python-version }}
-    # Manual build step required because tox only builds an sdist and not wheels.
-    - name: Build distributions
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ${{ env.PIP_REQUIREMENTS }}
-        python setup.py sdist bdist_wheel
+        name: distributions
+        path: dist
+
     - name: Publish package to TestPyPI
       # Use SHA-1 hash because this GitHub Action isn't mature yet
       # TODO: Replace hash with a tag name when this becomes stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,13 @@ on:
 
 env:
   PIP_REQUIREMENTS: requirements-dev.txt
+  # Default Python version for running build and lint jobs
+  python-version: 3.8
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    env:
-      python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
@@ -51,6 +50,49 @@ jobs:
       with:
         name: distributions
         path: dist
+
+  lint:
+
+    runs-on: ubuntu-latest
+    # Use the build matrix to reuse steps across lint jobs
+    # TODO: Separate this into individual jobs when GitHub Actions gain support
+    # for YAML aliases and anchors.
+    strategy:
+      matrix:
+        lint-tool: [black, isort, pylint]
+        include:
+          - lint-tool: black
+            run: black --check .
+          - lint-tool: isort
+            run: isort --check-only
+          - lint-tool: pylint
+            run: pylint *.py tests
+      # Make all lint jobs run to completion for combined diagnosis
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ env.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ env.python-version }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ env.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies (${{ env.PIP_REQUIREMENTS }})
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ env.PIP_REQUIREMENTS }}
+
+    - name: Run ${{ matrix.lint-tool }}
+      run: ${{ matrix.run }}
 
   test:
 
@@ -111,7 +153,9 @@ jobs:
 
   publish:
 
-    needs: test
+    needs:
+      - lint
+      - test
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,28 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    # Load different caches for each runner.os
+    # Based on https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
+    - name: Cache dependencies (Linux)
+      uses: actions/cache@v1
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+    - name: Cache dependencies (Windows)
+      uses: actions/cache@v1
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
     - name: Install development dependencies (${{ env.PIP_REQUIREMENTS }})
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# This workflow will install Python dependencies and run tests.
+# Based on https://github.com/actions/starter-workflows/blob/master/ci/python-package.yml
+
+name: Build
+
+on: push
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.7, 3.8]
+
+    env:
+      PIP_REQUIREMENTS: requirements-dev.txt
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install development dependencies (${{ env.PIP_REQUIREMENTS }})
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ env.PIP_REQUIREMENTS }}
+    - name: Test with tox
+      run: tox -e py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,9 +167,7 @@ jobs:
         path: dist
 
     - name: Publish package to TestPyPI
-      # Use SHA-1 hash because this GitHub Action isn't mature yet
-      # TODO: Replace hash with a tag name when this becomes stable
-      uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,9 +166,8 @@ jobs:
         name: distributions
         path: dist
 
-    - name: Publish package to TestPyPI
+    - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # d2animdata
+![Build status](https://github.com/pastelmind/d2animdata/workflows/Build/badge.svg)
+
 Python script that can decompile Diablo 2's AnimData.D2 to tabbed TXT and JSON, or compile them back to AnimData.D2. Useful for managing Diablo 2 mods inside a version control system, such as Git.
 
 This project is very much in alpha.


### PR DESCRIPTION
Create a Build Workflow

- [x] Add `test` Job that runs [tox](https://tox.readthedocs.io/)
- [x] Add `publish` Job for publishing releases to [Test PyPI](https://test.pypi.org/)
    - [x] Convert this Workflow to use [PyPI](https://pypi.org/)
- [x] Add `lint` Job that runs [Pylint](https://www.pylint.org/)
- [ ] Add status badge to README

Status badge: ![Build status](https://github.com/pastelmind/d2animdata/workflows/Build/badge.svg)

## Badges

Initially, I wanted to create separate badges for building, testing, and linting, a la:

![build|passing (display only)](https://img.shields.io/badge/build-passing-success)
![test|passing (display only)](https://img.shields.io/badge/test-passing-success)
![lint|failing (display only)](https://img.shields.io/badge/lint-failing-critical)

However, it looks like I can make only one badge per workflow. Since I intend to run Pylint, black, and (maybe) isort before building anyway, creating extraneous workflows just to have multiple badges is over the top.

See: [Adding a workflow status badge to your repository](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository) ([permalink](https://archive.is/r1pHx#adding-a-workflow-status-badge-to-your-repository))

