### PR TITLE
⚡Split requirements-dev.txt for build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
     types: [published]
 
 env:
-  PIP_REQUIREMENTS: requirements-dev.txt
   # Default Python version for running build and lint jobs
   python-version: 3.8
 
@@ -19,6 +18,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      PIP_REQUIREMENTS: requirements-build-test.txt
 
     steps:
     - uses: actions/checkout@v2
@@ -54,6 +55,8 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    env:
+      PIP_REQUIREMENTS: requirements-lint.txt
     # Use the build matrix to reuse steps across lint jobs
     # TODO: Separate this into individual jobs when GitHub Actions gain support
     # for YAML aliases and anchors.
@@ -98,6 +101,8 @@ jobs:
 
     needs: build
     runs-on: ${{ matrix.os }}
+    env:
+      PIP_REQUIREMENTS: requirements-build-test.txt
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/requirements-build-test.txt
+++ b/requirements-build-test.txt
@@ -1,0 +1,4 @@
+# Dependencies for building and testing
+setuptools~=41.2.0
+tox~=3.14.5
+wheel~=0.34.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,4 @@
-black~=19.10b0
-isort~=4.3.21
+# Dependencies for general development
+-r requirements-build-test.txt
+-r requirements-lint.txt
 pipdeptree~=0.13.2
-pylint~=2.4.4
-setuptools~=41.2.0
-tox~=3.14.5
-wheel~=0.34.2

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,4 @@
+# Dependencies for linting source code
+black~=19.10b0
+isort~=4.3.21
+pylint~=2.4.4


### PR DESCRIPTION
Split requirements-dev.txt into three files:

* `requirements-lint.txt`: Specifies linting tools (Black, isort, Pylint)
     These tools do not require a build step or a test runner.
* `requirements-build-test.txt`: Specifies tools for building sdists and
     wheels, as well as running tests.
     These are combined because tox needs to build sdists anyway.
* `requirements-dev.txt`: Pulls in all of the above, and also specifies
     some utilities used exclusively for development.

Splitting requirements-dev.txt reduces the number of dependencies
installed during each CI Job, (hopefully) speeding up the process.

Resolves #3