### PR TITLE
Add --dedupe CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Decompiles an AnimData.D2 file to tabbed text or JSON file.
 
 ```console
 $ d2animdata decompile --help
-usage: d2animdata decompile [-h] [--sort] (--json | --txt) animdata_d2 target
+usage: d2animdata decompile [-h] [--dedupe] [--sort] (--json | --txt)
+                            animdata_d2 target
 
 positional arguments:
   animdata_d2  AnimData.D2 file to decompile
@@ -46,6 +47,7 @@ positional arguments:
 
 optional arguments:
   -h, --help   show this help message and exit
+  --dedupe     Remove records with duplicate COF names
   --sort       Sort the records alphabetically before saving
   --json       Decompile to JSON
   --txt        Decompile to tabbed text (TXT)
@@ -67,7 +69,8 @@ Compiles a tabbed text or JSON file to AnimData.D2 file.
 
 ```console
 $ d2animdata compile --help
-usage: d2animdata compile [-h] [--sort] (--json | --txt) source animdata_d2
+usage: d2animdata compile [-h] [--dedupe] [--sort] (--json | --txt)
+                          source animdata_d2
 
 positional arguments:
   source       JSON or tabbed text file to compile
@@ -75,6 +78,7 @@ positional arguments:
 
 optional arguments:
   -h, --help   show this help message and exit
+  --dedupe     Remove records with duplicate COF names
   --sort       Sort the records alphabetically before saving
   --json       Compile JSON
   --txt        Compile tabbed text (TXT)

--- a/src/d2animdata.py
+++ b/src/d2animdata.py
@@ -626,6 +626,9 @@ def _init_subparser_compile(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("source", help="JSON or tabbed text file to compile")
     parser.add_argument("animdata_d2", help="AnimData.D2 file to save to")
     parser.add_argument(
+        "--dedupe", action="store_true", help="Remove records with duplicate COF names",
+    )
+    parser.add_argument(
         "--sort",
         action="store_true",
         help="Sort the records alphabetically before saving",
@@ -650,7 +653,11 @@ def _cli_compile(args: argparse.Namespace) -> None:
     else:
         raise ValueError("No file format specified")
 
-    _consume(_dedupe_cof_names(records))
+    if args.dedupe:
+        records = list(_dedupe_cof_names(records))
+    else:
+        _consume(_dedupe_cof_names(records))
+
     for record in records:
         _check_out_of_bounds_triggers(record)
     if args.sort:
@@ -664,6 +671,9 @@ def _init_subparser_decompile(parser: argparse.ArgumentParser) -> None:
     """Initialize the argument subparser for the `decompile` command."""
     parser.add_argument("animdata_d2", help="AnimData.D2 file to decompile")
     parser.add_argument("target", help="JSON or tabbed text file to save to")
+    parser.add_argument(
+        "--dedupe", action="store_true", help="Remove records with duplicate COF names",
+    )
     parser.add_argument(
         "--sort",
         action="store_true",
@@ -682,7 +692,11 @@ def _cli_decompile(args: argparse.Namespace):
     with open(args.animdata_d2, mode="rb") as animdata_d2_file:
         records = load(animdata_d2_file)
 
-    _consume(_dedupe_cof_names(records))
+    if args.dedupe:
+        records = list(_dedupe_cof_names(records))
+    else:
+        _consume(_dedupe_cof_names(records))
+
     for record in records:
         _check_out_of_bounds_triggers(record)
     if args.sort:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,88 @@
 """Integration tests for the command-line interface."""
 
+import logging
 import unittest
 from io import BytesIO, StringIO
 from unittest import mock
 
+import d2animdata
 from d2animdata import main
 
 from .valid_data import VALID_ANIMDATA, VALID_JSON, VALID_TXT
+
+# AnimData.D2 with two records that have the same COF name.
+# This decompiles to DUPLICATE_COF_JSON with warnings.
+DUPLICATE_COF_ANIMDATA = (
+    # Start of block 0
+    b"\x02\x00\x00\x00"  # # of records in block
+    # start of record 0 in block 0
+    + b"BVS1HTH\x00"  # COF name (hash value == 0)
+    + b"\x09\x00\x00\x00"  # frames_per_direction
+    + b"\x07\x00\x00\x00"  # animation_speed
+    + b"\x00\x03\x02\x01"  # First four frames have trigger codes 0, 3, 2, 1
+    + b"\x00" * 140  # All other frames have no trigger code
+    # End of record 0 in block 0
+    # start of record 1 in block 0
+    + b"BVS1HTH\x00"  # COF name (hash value == 0)
+    + b"\x11\x00\x00\x00"  # frames_per_direction
+    + b"\x20\x00\x00\x00"  # animation_speed
+    + b"\x00" * 144  # All frames have no trigger code
+    # End of record 1 in block 0
+    # End of block 0
+    # All other blocks are empty
+    + b"\x00\x00\x00\x00" * 255
+)
+
+# Deduplicated version of DUPLICATE_COF_ANIMDATA.
+DEDUPED_ANIMDATA = (
+    # Start of block 0
+    b"\x01\x00\x00\x00"  # # of records in block
+    # start of record 0 in block 0
+    + b"BVS1HTH\x00"  # COF name (hash value == 0)
+    + b"\x09\x00\x00\x00"  # frames_per_direction
+    + b"\x07\x00\x00\x00"  # animation_speed
+    + b"\x00\x03\x02\x01"  # First four frames have trigger codes 0, 3, 2, 1
+    + b"\x00" * 140  # All other frames have no trigger code
+    # End of record 0 in block 0
+    # End of block 0
+    # All other blocks are empty
+    + b"\x00\x00\x00\x00" * 255
+)
+
+# Expected result of decompiling DUPLICATE_COF_ANIMDATA.
+# This compiles to DUPLICATE_COF_ANIMDATA with warnings.
+DUPLICATE_COF_JSON = """[
+  {
+    "cof_name": "BVS1HTH",
+    "frames_per_direction": 9,
+    "animation_speed": 7,
+    "triggers": {
+      "1": 3,
+      "2": 2,
+      "3": 1
+    }
+  },
+  {
+    "cof_name": "BVS1HTH",
+    "frames_per_direction": 17,
+    "animation_speed": 32,
+    "triggers": {}
+  }
+]"""
+
+# Deduplicated version of DUPLICATE_COF_JSON.
+DEDUPED_JSON = """[
+  {
+    "cof_name": "BVS1HTH",
+    "frames_per_direction": 9,
+    "animation_speed": 7,
+    "triggers": {
+      "1": 3,
+      "2": 2,
+      "3": 1
+    }
+  }
+]"""
 
 
 class TestCompile(unittest.TestCase):
@@ -54,6 +130,48 @@ class TestCompile(unittest.TestCase):
         animdata_d2_file.close.assert_called_once_with()
         self.assertEqual(animdata_d2_file.getvalue(), VALID_ANIMDATA)
 
+    @mock.patch("builtins.open", autospec=True)
+    def test_compile_no_dedupe(self, mock_open: mock.Mock) -> None:
+        """By default, records with duplicate COF names cause warnings to be
+        logged, but are not deduplicated."""
+        json_file = StringIO(DUPLICATE_COF_JSON)
+        animdata_d2_file = BytesIO()
+        animdata_d2_file.close = mock.Mock(spec=animdata_d2_file.close)
+        mock_open.side_effect = [json_file, animdata_d2_file]
+
+        with self.assertLogs(d2animdata.logger, logging.WARNING) as logs:
+            main("compile --json AnimData.json-file AnimData.D2-file".split())
+        self.assertEqual(
+            logs.output, ["WARNING:d2animdata:Duplicate entry found: BVS1HTH"]
+        )
+
+        mock_open.assert_has_calls(
+            [mock.call("AnimData.json-file"), mock.call("AnimData.D2-file", mode="wb"),]
+        )
+        animdata_d2_file.close.assert_called_once_with()
+        self.assertEqual(animdata_d2_file.getvalue(), DUPLICATE_COF_ANIMDATA)
+
+    @mock.patch("builtins.open", autospec=True)
+    def test_compile_dedupe(self, mock_open: mock.Mock) -> None:
+        """Specifying --dedupe causes records with duplicate COF names to be
+        deduplicated, always favoring the first item."""
+        json_file = StringIO(DUPLICATE_COF_JSON)
+        animdata_d2_file = BytesIO()
+        animdata_d2_file.close = mock.Mock(spec=animdata_d2_file.close)
+        mock_open.side_effect = [json_file, animdata_d2_file]
+
+        with self.assertLogs(d2animdata.logger, logging.WARNING) as logs:
+            main("compile --json --dedupe AnimData.json-file AnimData.D2-file".split())
+        self.assertEqual(
+            logs.output, ["WARNING:d2animdata:Duplicate entry found: BVS1HTH"]
+        )
+
+        mock_open.assert_has_calls(
+            [mock.call("AnimData.json-file"), mock.call("AnimData.D2-file", mode="wb"),]
+        )
+        animdata_d2_file.close.assert_called_once_with()
+        self.assertEqual(animdata_d2_file.getvalue(), DEDUPED_ANIMDATA)
+
 
 class TestDecompile(unittest.TestCase):
     """Test case for the `decompile` command."""
@@ -99,3 +217,53 @@ class TestDecompile(unittest.TestCase):
         )
         json_file.close.assert_called_once_with()
         self.assertEqual(json_file.getvalue(), VALID_JSON)
+
+    @mock.patch("builtins.open", autospec=True)
+    def test_compile_no_dedupe(self, mock_open: mock.Mock) -> None:
+        """By default, records with duplicate COF names cause warnings to be
+        logged, but are not deduplicated."""
+        animdata_d2_file = BytesIO(DUPLICATE_COF_ANIMDATA)
+        json_file = StringIO()
+        json_file.close = mock.Mock(spec=json_file.close)
+        mock_open.side_effect = [animdata_d2_file, json_file]
+
+        with self.assertLogs(d2animdata.logger, logging.WARNING) as logs:
+            main("decompile --json AnimData.D2-file AnimData.json-file".split())
+        self.assertEqual(
+            logs.output, ["WARNING:d2animdata:Duplicate entry found: BVS1HTH"]
+        )
+
+        mock_open.assert_has_calls(
+            [
+                mock.call("AnimData.D2-file", mode="rb"),
+                mock.call("AnimData.json-file", mode="w"),
+            ]
+        )
+        json_file.close.assert_called_once_with()
+        self.assertEqual(json_file.getvalue(), DUPLICATE_COF_JSON)
+
+    @mock.patch("builtins.open", autospec=True)
+    def test_compile_dedupe(self, mock_open: mock.Mock) -> None:
+        """Specifying --dedupe causes records with duplicate COF names to be
+        deduplicated, always favoring the first item."""
+        animdata_d2_file = BytesIO(DUPLICATE_COF_ANIMDATA)
+        json_file = StringIO()
+        json_file.close = mock.Mock(spec=json_file.close)
+        mock_open.side_effect = [animdata_d2_file, json_file]
+
+        with self.assertLogs(d2animdata.logger, logging.WARNING) as logs:
+            main(
+                "decompile --json --dedupe AnimData.D2-file AnimData.json-file".split()
+            )
+        self.assertEqual(
+            logs.output, ["WARNING:d2animdata:Duplicate entry found: BVS1HTH"]
+        )
+
+        mock_open.assert_has_calls(
+            [
+                mock.call("AnimData.D2-file", mode="rb"),
+                mock.call("AnimData.json-file", mode="w"),
+            ]
+        )
+        json_file.close.assert_called_once_with()
+        self.assertEqual(json_file.getvalue(), DEDUPED_JSON)


### PR DESCRIPTION
When given, this causes d2animdata to also remove (in addition to printing warnings for) records with duplicate COF names.

If two or more records have the same COF name, the first (topmost) in the input file is used, and all others are discarded. As far as I know, this matches how Diablo 2 treats duplicate COF names--traverse the hash table block and use the first match.