### PR TITLE
Update GitHub Actions used in the CI script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         pip install -r ${{ env.PIP_REQUIREMENTS }}
 
     - name: Download distributions
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: distributions
         path: dist
@@ -167,7 +167,7 @@ jobs:
 
     steps:
     - name: Download distributions
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: distributions
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ env.python-version }}
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
@@ -82,7 +82,7 @@ jobs:
         python-version: ${{ env.python-version }}
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ env.python-version }}-${{ hashFiles(env.PIP_REQUIREMENTS) }}
@@ -119,7 +119,7 @@ jobs:
     # Load different caches for each runner.os
     # Based on https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
     - name: Cache dependencies (Linux)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: startsWith(runner.os, 'Linux')
       with:
         path: ~/.cache/pip
@@ -128,7 +128,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-
     - name: Cache dependencies (Windows)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: startsWith(runner.os, 'Windows')
       with:
         path: ~\AppData\Local\pip\Cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       run: flit build
 
     - name: Upload distributions
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: distributions
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ env.python-version }}
 
@@ -77,7 +77,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ env.python-version }}
 
@@ -112,7 +112,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Update the tags for the following GitHub actions:

- [actions/setup-python](https://github.com/actions/setup-python): `v1` → `v2`
- [actions/cache](https://github.com/actions/cache): `v1` → `v2`
- [actions/upload-artifact](https://github.com/actions/upload-artifact): `v1` → `v2`
- [actions/download-artifact](https://github.com/actions/download-artifact): `v1` → `v2`